### PR TITLE
First implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,10 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.slf4j" % "slf4j-simple" % "1.7.25"
+  "org.slf4j" % "slf4j-simple" % "1.7.25",
+  "com.typesafe.play" %% "play-json" % "2.6.2",
+  "com.amazonaws" % "aws-java-sdk-ses" % "1.11.165",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -62,9 +62,9 @@ Resources:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
-      Description: This project checks the certificates referenced in prism are up to date, otherwise warns the respective team owners.
+      Description: Checks the validity of ACM certificates
       Handler: com.gu.certw.Lambda::handler
-      MemorySize: 128
+      MemorySize: 256
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 60
@@ -72,8 +72,8 @@ Resources:
   DailyEvent:
     Type: AWS::Events::Rule
     Properties:
-      Description: Event sent to process the previous day of data
-      ScheduleExpression: cron(14 3 * * ? *)
+      Description: Event sent to trigger the certificate-watchdog lambda
+      ScheduleExpression: cron(0 10 * * ? *)
       Targets:
         - Id: Lambda
           Arn: !GetAtt Lambda.Arn

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -62,6 +62,8 @@ Resources:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
+          PrismDomain: !Ref PrismDomain
+          SenderEmail: !Ref SenderEmail
       Description: Checks the validity of ACM certificates
       Handler: com.gu.certw.Lambda::handler
       MemorySize: 256

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -20,6 +20,12 @@ Parameters:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
     Default: deploy-tools-dist
+  VpcId:
+    Description: VPC ID
+    Type: AWS::EC2::VPC::Id
+  Subnets:
+    Description: VPC's subnets
+    Type: List<AWS::EC2::Subnet::Id>
 Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -33,22 +39,29 @@ Resources:
             Action: sts:AssumeRole
       Path: /
       Policies:
-        - PolicyName: logs
+        - PolicyName: email
           PolicyDocument:
             Statement:
               Effect: Allow
               Action:
-                - logs:CreateLogGroup
-                - logs:CreateLogStream
-                - logs:PutLogEvents
-              Resource: arn:aws:logs:*:*:*
-        - PolicyName: lambda
-          PolicyDocument:
-            Statement:
-              Effect: Allow
-              Action:
-                - lambda:InvokeFunction
+                - ses:SendEmail
               Resource: "*"
+        - PolicyName: vpc
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - ec2:CreateNetworkInterface
+                - ec2:DescribeNetworkInterfaces
+                - ec2:DeleteNetworkInterface
+              Resource: "*"
+
+  LambdaSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Open access to prism
+      VpcId: !Ref VpcId
+
   Lambda:
     Type: AWS::Lambda::Function
     Properties:
@@ -69,7 +82,10 @@ Resources:
       MemorySize: 256
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
-      Timeout: 60
+      Timeout: 120
+      VpcConfig:
+        SubnetIds: !Ref Subnets
+        SecurityGroupIds: [!GetAtt LambdaSecurityGroup.GroupId]
 
   DailyEvent:
     Type: AWS::Events::Rule

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.8")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.9")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.7.0")

--- a/src/main/scala/com/gu/certw/Lambda.scala
+++ b/src/main/scala/com/gu/certw/Lambda.scala
@@ -1,25 +1,48 @@
 package com.gu.certw
 
-import org.slf4j.{ Logger, LoggerFactory }
+import java.time.ZonedDateTime
 
-case class Env(app: String, stack: String, stage: String) {
-  override def toString: String = s"App: $app, Stack: $stack, Stage: $stage\n"
+import com.amazonaws.auth.{ AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain }
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.simpleemail.{ AmazonSimpleEmailService, AmazonSimpleEmailServiceAsyncClientBuilder }
+import com.gu.certw.services.{ CertificateService, DefaultHttpClient }
+
+case class Env(app: String, stack: String, stage: String, prismDomain: String, senderEmail: String) {
+  override def toString: String = s"App: $app, Stack: $stack, Stage: $stage"
 }
 
 object Env {
   def apply(): Env = Env(
     Option(System.getenv("App")).getOrElse("DEV"),
     Option(System.getenv("Stack")).getOrElse("DEV"),
-    Option(System.getenv("Stage")).getOrElse("DEV"))
+    Option(System.getenv("Stage")).getOrElse("DEV"),
+    Option(System.getenv("PrismDomain")).get,
+    Option(System.getenv("SenderEmail")).get)
 }
 
-object Lambda {
+object Lambda extends Logging {
 
-  val logger: Logger = LoggerFactory.getLogger(this.getClass)
+  val credentials = new AWSCredentialsProviderChain(
+    new ProfileCredentialsProvider("deployTools"),
+    DefaultAWSCredentialsProviderChain.getInstance())
+
+  val ses: AmazonSimpleEmailService = AmazonSimpleEmailServiceAsyncClientBuilder.standard()
+    .withCredentials(credentials)
+    .withRegion(Regions.EU_WEST_1)
+    .build()
+
+  val httpClient = new DefaultHttpClient
+  val certificateService = new CertificateService(httpClient, ses)
 
   def handler(): Unit = {
-    val env = Env()
-    logger.info(s"Starting $env")
+    logger.info(s"Starting ${Env()}")
+
+    val certificates = certificateService.listCertificates
+    val expireSoon = certificateService.soonToExpire(certificates, ZonedDateTime.now())
+    val arns = expireSoon.map(_.arn)
+    logger.info(s"Certificates about to expire: $arns")
+    certificateService.sendEmails(expireSoon)
   }
 }
 

--- a/src/main/scala/com/gu/certw/Logging.scala
+++ b/src/main/scala/com/gu/certw/Logging.scala
@@ -1,0 +1,7 @@
+package com.gu.certw
+
+import org.slf4j.{ Logger, LoggerFactory }
+
+trait Logging {
+  val logger: Logger = LoggerFactory.getLogger(this.getClass)
+}

--- a/src/main/scala/com/gu/certw/models/Certificate.scala
+++ b/src/main/scala/com/gu/certw/models/Certificate.scala
@@ -1,0 +1,12 @@
+package com.gu.certw.models
+
+import java.time.ZonedDateTime
+
+case class Certificate(
+  arn: String,
+  domainName: String,
+  status: String,
+  inUseBy: List[String],
+  notAfter: Option[ZonedDateTime],
+  ownerId: String,
+  accountName: String)

--- a/src/main/scala/com/gu/certw/models/Email.scala
+++ b/src/main/scala/com/gu/certw/models/Email.scala
@@ -1,0 +1,5 @@
+package com.gu.certw.models
+
+case class Email(
+  to: String,
+  certificate: Certificate)

--- a/src/main/scala/com/gu/certw/models/Email.scala
+++ b/src/main/scala/com/gu/certw/models/Email.scala
@@ -2,4 +2,5 @@ package com.gu.certw.models
 
 case class Email(
   to: String,
-  certificate: Certificate)
+  subject: String,
+  message: String)

--- a/src/main/scala/com/gu/certw/services/CertificateService.scala
+++ b/src/main/scala/com/gu/certw/services/CertificateService.scala
@@ -54,7 +54,7 @@ object CertificateService extends Logging {
            |Please check if this certificate is still needed and renew it as soon as possible
            |""".stripMargin
 
-      val subject = s"[Urgent] SSL/TLS Certificate for ${certificate.domainName} is about to expire"
+      val subject = s"[Action required] SSL/TLS Certificate for ${certificate.domainName} is about to expire"
 
       Email(to, subject, message)
     }

--- a/src/main/scala/com/gu/certw/services/CertificateService.scala
+++ b/src/main/scala/com/gu/certw/services/CertificateService.scala
@@ -1,0 +1,68 @@
+package com.gu.certw.services
+
+import java.net.URI
+import java.time.ZonedDateTime
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService
+import com.amazonaws.services.simpleemail.model._
+import com.gu.certw.{Env, Logging}
+import com.gu.certw.models._
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{ JsPath, Json, Reads }
+
+class CertificateService(httpClient: HttpClient, ses: AmazonSimpleEmailService) extends Logging {
+
+  private implicit val prismAcmCertificateParser: Reads[Certificate] = (
+    (JsPath \ "arn").read[String] and
+    (JsPath \ "domainName").read[String] and
+    (JsPath \ "status").read[String] and
+    (JsPath \ "inUseBy").read[List[String]] and
+    (JsPath \ "notAfter").readNullable[ZonedDateTime] and
+    (JsPath \ "meta" \ "origin" \ "ownerId").read[String] and
+    (JsPath \ "meta" \ "origin" \ "accountName").read[String])(Certificate.apply _)
+
+  def listCertificates: List[Certificate] = {
+    val body = httpClient.get(new URI(s"https://${Env().prismDomain}/acm-certificates"))
+    (Json.parse(body) \ "data" \ "acmCertificates").as[List[Certificate]]
+  }
+
+  private val activeOrExpired = Set("ISSUED", "EXPIRED")
+
+  def soonToExpire(certificates: List[Certificate], now: ZonedDateTime): List[Certificate] = certificates
+    .filter(cert => activeOrExpired.contains(cert.status))
+    .filter(_.inUseBy.nonEmpty)
+    .filter(_.notAfter.forall(_.isBefore(now.plusDays(29))))
+
+  def sendEmails(certificates: List[Certificate]): Unit = {
+    certificates.foreach { certificate =>
+      val to = s"${certificate.ownerId}@theguardian.com"
+      val message =
+        s"""
+           |The certificate for the domain ${certificate.domainName} is expired or is about to expire.
+           |
+           |AWS account: ${certificate.accountName}
+           |ARN: ${certificate.arn}
+           |Valid until: ${certificate.notAfter.getOrElse("unknown")}
+           |Status: ${certificate.status}
+           |Owned by: ${certificate.ownerId}
+           |Used by the following resources:
+           |${certificate.inUseBy.map(r => s" - $r").mkString("\n")}
+           |
+           |Please check if that certicate is still needed and renew it as soon as possible
+         """.stripMargin
+
+      logger.info(s"Sending email about ${certificate.domainName} ${certificate.arn}")
+
+      val request = new SendEmailRequest()
+        .withDestination(new Destination().withToAddresses(to))
+        .withSource(Env().senderEmail)
+        .withMessage(new Message()
+          .withSubject(new Content(s"[Urgent] SSL/TLS Certificate for ${certificate.domainName} is about to expire"))
+          .withBody(new Body(new Content(message))))
+
+      ses.sendEmail(request)
+    }
+
+  }
+
+}

--- a/src/main/scala/com/gu/certw/services/HttpClient.scala
+++ b/src/main/scala/com/gu/certw/services/HttpClient.scala
@@ -1,0 +1,15 @@
+package com.gu.certw.services
+
+import java.net.URI
+
+import scala.io.Source
+
+trait HttpClient {
+  def get(uri: URI): String
+}
+
+class DefaultHttpClient extends HttpClient {
+  override def get(uri: URI): String = {
+    Source.fromInputStream(uri.toURL.openStream()).mkString
+  }
+}

--- a/src/test/scala/com/gu/certw/services/CertificateServiceSpec.scala
+++ b/src/test/scala/com/gu/certw/services/CertificateServiceSpec.scala
@@ -3,7 +3,8 @@ package com.gu.certw.services
 import java.net.URI
 import java.time.ZonedDateTime
 
-import com.gu.certw.models.Certificate
+import com.gu.certw.Env
+import com.gu.certw.models.{ Certificate, Email }
 import org.scalatest._
 
 class CertificateServiceSpec extends FlatSpec with Matchers {
@@ -11,6 +12,8 @@ class CertificateServiceSpec extends FlatSpec with Matchers {
   def httpClient(result: String): HttpClient = new HttpClient {
     override def get(uri: URI) = result
   }
+
+  val env = Env("app", "stack", "stage", "prism.com", "a@prism.com")
 
   "The certificate service" should "parse a list of certificates" in {
     val json = """{
@@ -98,13 +101,11 @@ class CertificateServiceSpec extends FlatSpec with Matchers {
         ownerId = "someOwner2",
         accountName = "someAccount2"))
 
-    val service = new CertificateService(httpClient(json), null)
-    val certificates = service.listCertificates
+    val certificates = CertificateService.listCertificates(env, httpClient(json))
     certificates shouldEqual expectedCertificates
   }
 
   it should "only keep the certificates that are about to expire (29 days)" in {
-    val service = new CertificateService(httpClient(""), null)
     val c1 = Certificate(
       arn = "arn:aws:acm:eu-west-1:7784783487:certificate/blah",
       domainName = "somedomain.com",
@@ -116,12 +117,11 @@ class CertificateServiceSpec extends FlatSpec with Matchers {
     val c2 = c1.copy(notAfter = Some(ZonedDateTime.parse("2017-10-07T12:00:00.000Z")))
 
     val certificates = List(c1, c2)
-    val expiringSoon = service.soonToExpire(certificates, now = ZonedDateTime.parse("2017-09-08T12:00:00.000Z"))
+    val expiringSoon = CertificateService.soonToExpire(certificates, now = ZonedDateTime.parse("2017-09-08T12:00:00.000Z"))
     expiringSoon shouldEqual List(c1)
   }
 
   it should "ignore certificate when their status is other than ISSUED and EXPIRED" in {
-    val service = new CertificateService(httpClient(""), null)
     val c1 = Certificate(
       arn = "arn:aws:acm:eu-west-1:7784783487:certificate/blah",
       domainName = "somedomain.com",
@@ -134,7 +134,37 @@ class CertificateServiceSpec extends FlatSpec with Matchers {
     val c3 = c1.copy(status = "SOMETHING ELSE")
 
     val certificates = List(c1, c2, c3)
-    val expiringSoon = service.soonToExpire(certificates, now = ZonedDateTime.parse("2017-09-10T12:00:00.000Z"))
+    val expiringSoon = CertificateService.soonToExpire(certificates, now = ZonedDateTime.parse("2017-09-10T12:00:00.000Z"))
     expiringSoon shouldEqual List(c1, c2)
+  }
+
+  it should "generate emails" in {
+    val c1 = Certificate(
+      arn = "arn:aws:acm:eu-west-1:7784783487:certificate/blah",
+      domainName = "somedomain.com",
+      status = "ISSUED",
+      inUseBy = List("arn:aws:elasticloadbalancing:eu-west-1:7784783487:loadbalancer/bleh"),
+      notAfter = Some(ZonedDateTime.parse("2017-10-06T12:00:00.000Z")),
+      ownerId = "someOwner",
+      accountName = "someAccount")
+
+    val expectedMessage =
+      """
+      |The certificate for the domain somedomain.com is expired or is about to expire.
+      |
+      |AWS account: someAccount
+      |ARN: arn:aws:acm:eu-west-1:7784783487:certificate/blah
+      |Valid until: 2017-10-06T12:00Z
+      |Status: ISSUED
+      |Owned by: someOwner
+      |Used by the following resources:
+      | - arn:aws:elasticloadbalancing:eu-west-1:7784783487:loadbalancer/bleh
+      |
+      |Please check if this certificate is still needed and renew it as soon as possible
+      |""".stripMargin
+
+    val expectedSubject = "[Urgent] SSL/TLS Certificate for somedomain.com is about to expire"
+    val emails = CertificateService.generateEmails(List(c1))
+    emails shouldEqual List(Email("someOwner@theguardian.com", expectedSubject, expectedMessage))
   }
 }

--- a/src/test/scala/com/gu/certw/services/CertificateServiceSpec.scala
+++ b/src/test/scala/com/gu/certw/services/CertificateServiceSpec.scala
@@ -1,0 +1,140 @@
+package com.gu.certw.services
+
+import java.net.URI
+import java.time.ZonedDateTime
+
+import com.gu.certw.models.Certificate
+import org.scalatest._
+
+class CertificateServiceSpec extends FlatSpec with Matchers {
+
+  def httpClient(result: String): HttpClient = new HttpClient {
+    override def get(uri: URI) = result
+  }
+
+  "The certificate service" should "parse a list of certificates" in {
+    val json = """{
+                 |
+                 |    "status": "success",
+                 |    "lastUpdated": "2017-07-19T16:24:26.686Z",
+                 |    "stale": false,
+                 |    "staleSources": [ ],
+                 |    "data": {
+                 |        "acmCertificates": [
+                 |            {
+                 |                "arn": "arn:aws:acm:eu-west-1:7784783487:certificate/blah",
+                 |                "domainName": "somedomain.com",
+                 |                "certificateType": "AMAZON_ISSUED",
+                 |                "status": "EXPIRED",
+                 |                "issuer": "Amazon",
+                 |                "inUseBy": [
+                 |                    "arn:aws:elasticloadbalancing:eu-west-1:7784783487:loadbalancer/bleh"
+                 |                ],
+                 |                "notBefore": "2016-09-06T00:00:00.000Z",
+                 |                "createdAt": "2016-09-06T14:08:02.000Z",
+                 |                "issuedAt": "2016-09-06T14:40:40.000Z",
+                 |                "subject": "CN=somedomain2.com",
+                 |                "keyAlgorithm": "RSA-2048",
+                 |                "signatureAlgorithm": "SHA256WITHRSA",
+                 |                "meta": {
+                 |                    "href": "http://someDomain/acm-certificates/arn:aws:acm:eu-west-1:7784783487:certificate%2Fbleh",
+                 |                    "origin": {
+                 |                        "accountName": "someAccount",
+                 |                        "ownerId": "someOwner",
+                 |                        "region": "eu-west-1",
+                 |                        "accountNumber": "7784783487",
+                 |                        "vendor": "aws",
+                 |                        "credentials": "arn:aws:iam::7784783487:role/PrismAccess-Prism"
+                 |                    }
+                 |                }
+                 |            },
+                 |            {
+                 |                "arn": "arn:aws:acm:eu-west-1:7784783487:certificate/blah2",
+                 |                "domainName": "somedomain2.com",
+                 |                "certificateType": "AMAZON_ISSUED",
+                 |                "status": "ISSUED",
+                 |                "issuer": "Amazon",
+                 |                "inUseBy": [
+                 |                    "arn:aws:elasticloadbalancing:eu-west-1:7784783487:loadbalancer/bleh2"
+                 |                ],
+                 |                "notBefore": "2016-09-06T00:00:00.000Z",
+                 |                "notAfter": "2017-10-06T12:00:00.000Z",
+                 |                "createdAt": "2016-09-06T14:08:02.000Z",
+                 |                "issuedAt": "2016-09-06T14:40:40.000Z",
+                 |                "subject": "CN=somedomain2.com",
+                 |                "keyAlgorithm": "RSA-2048",
+                 |                "signatureAlgorithm": "SHA256WITHRSA",
+                 |                "meta": {
+                 |                    "href": "http://somedomain/acm-certificates/arn:aws:acm:eu-west-1:7784783487:certificate%2Fbleh2",
+                 |                    "origin": {
+                 |                        "accountName": "someAccount2",
+                 |                        "ownerId": "someOwner2",
+                 |                        "region": "eu-west-1",
+                 |                        "accountNumber": "7784783487",
+                 |                        "vendor": "aws",
+                 |                        "credentials": "arn:aws:iam::7784783487:role/PrismAccess-Prism"
+                 |                    }
+                 |                }
+                 |            }
+                 |        ]
+                 |    }
+                 |}""".stripMargin
+
+    val expectedCertificates = List(
+      Certificate(
+        arn = "arn:aws:acm:eu-west-1:7784783487:certificate/blah",
+        domainName = "somedomain.com",
+        status = "EXPIRED",
+        inUseBy = List("arn:aws:elasticloadbalancing:eu-west-1:7784783487:loadbalancer/bleh"),
+        notAfter = None,
+        ownerId = "someOwner",
+        accountName = "someAccount"),
+      Certificate(
+        arn = "arn:aws:acm:eu-west-1:7784783487:certificate/blah2",
+        domainName = "somedomain2.com",
+        status = "ISSUED",
+        inUseBy = List("arn:aws:elasticloadbalancing:eu-west-1:7784783487:loadbalancer/bleh2"),
+        notAfter = Some(ZonedDateTime.parse("2017-10-06T12:00:00.000Z")),
+        ownerId = "someOwner2",
+        accountName = "someAccount2"))
+
+    val service = new CertificateService(httpClient(json), null)
+    val certificates = service.listCertificates
+    certificates shouldEqual expectedCertificates
+  }
+
+  it should "only keep the certificates that are about to expire (29 days)" in {
+    val service = new CertificateService(httpClient(""), null)
+    val c1 = Certificate(
+      arn = "arn:aws:acm:eu-west-1:7784783487:certificate/blah",
+      domainName = "somedomain.com",
+      status = "ISSUED",
+      inUseBy = List("arn:aws:elasticloadbalancing:eu-west-1:7784783487:loadbalancer/bleh"),
+      notAfter = Some(ZonedDateTime.parse("2017-10-06T12:00:00.000Z")),
+      ownerId = "someOwner",
+      accountName = "someAccount")
+    val c2 = c1.copy(notAfter = Some(ZonedDateTime.parse("2017-10-07T12:00:00.000Z")))
+
+    val certificates = List(c1, c2)
+    val expiringSoon = service.soonToExpire(certificates, now = ZonedDateTime.parse("2017-09-08T12:00:00.000Z"))
+    expiringSoon shouldEqual List(c1)
+  }
+
+  it should "ignore certificate when their status is other than ISSUED and EXPIRED" in {
+    val service = new CertificateService(httpClient(""), null)
+    val c1 = Certificate(
+      arn = "arn:aws:acm:eu-west-1:7784783487:certificate/blah",
+      domainName = "somedomain.com",
+      status = "ISSUED",
+      inUseBy = List("arn:aws:elasticloadbalancing:eu-west-1:7784783487:loadbalancer/bleh"),
+      notAfter = Some(ZonedDateTime.parse("2017-10-06T12:00:00.000Z")),
+      ownerId = "someOwner",
+      accountName = "someAccount")
+    val c2 = c1.copy(status = "EXPIRED")
+    val c3 = c1.copy(status = "SOMETHING ELSE")
+
+    val certificates = List(c1, c2, c3)
+    val expiringSoon = service.soonToExpire(certificates, now = ZonedDateTime.parse("2017-09-10T12:00:00.000Z"))
+    expiringSoon shouldEqual List(c1, c2)
+  }
+}


### PR DESCRIPTION
This implementation sends an email for every certificate in prism that is:
 - either ISSUED or EXPIRED
 - less than 29 days to expiry or expired already
 - used at least on one ELB or other resource

The email is pretty dry but should do the job.

Feedback more than welcome.