### PR TITLE
give the lambda the right to write to cloudwatch log

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -45,6 +45,15 @@ Resources:
             Action: sts:AssumeRole
       Path: /
       Policies:
+        - PolicyName: logs
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - logs:CreateLogGroup
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+              Resource: arn:aws:logs:*:*:*
         - PolicyName: email
           PolicyDocument:
             Statement:


### PR DESCRIPTION
I thought this was given through the assume role, but logs aren't coming through so I suppose it's necessary.